### PR TITLE
Allow custom extension for brotli files

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,25 @@
 npm install gulp-brotli
 ```
 
-### compress([brotliParams])
+## Options
 
-Output files will have the `.br` suffix added.
+### options `Object`
 
-The `brotliParams` object will be passed on to [iltorb](https://github.com/MayhemYDG/iltorb#brotliparams);
+Object that is passed on to [iltorb](https://github.com/MayhemYDG/iltorb#brotliparams).
+
+Besides the options for [iltorb](https://github.com/MayhemYDG/iltorb#brotliparams) the following properties can be set on the options object.
+
+#### extension `String`
+
+Appends a given extension to the filename. Defaults to `br`. Should not include a starting dot.
+
+## Examples
+
+### compress([options])
+
+#### Default compression
+
+Output files have the `.br` extension.
 
 ```javascript
 var gulp   = require('gulp');
@@ -29,9 +43,31 @@ gulp.task('example', function() {
 });
 ```
 
-### decompress()
+#### Custom compression
 
-Output files will have the `.br` suffix removed.
+Files are processed with maximum compression and output files have the `.brotli` extension.
+
+```javascript
+var gulp   = require('gulp');
+var brotli = require('gulp-brotli');
+
+gulp.task('example', function() {
+  return gulp.src('path/to/input')
+    .pipe(brotli.compress({
+      extension: 'brotli',
+      mode: 0,
+      quality: 11,
+      lgblock: 0
+    }))
+    .pipe(gulp.dest('path/to/output'));
+});
+```
+
+### decompress([options])
+
+#### Default decompression
+
+Output files will have the `.br` extension removed.
 
 ```javascript
 var gulp   = require('gulp');
@@ -40,6 +76,23 @@ var brotli = require('gulp-brotli');
 gulp.task('example', function() {
   return gulp.src('path/to/input')
     .pipe(brotli.decompress())
+    .pipe(gulp.dest('path/to/output'));
+});
+```
+
+#### Custom decompression
+
+Files with the `.brotli` extension are processed. Output files will have the `.brotli` extension removed.
+
+```javascript
+var gulp   = require('gulp');
+var brotli = require('gulp-brotli');
+
+gulp.task('example', function() {
+  return gulp.src('path/to/input')
+    .pipe(brotli.decompress({
+      extension: 'brotli'
+    }))
     .pipe(gulp.dest('path/to/output'));
 });
 ```

--- a/index.js
+++ b/index.js
@@ -6,8 +6,14 @@ exports.decompress = decompress;
 var brotli  = require('iltorb');
 var through = require('through2');
 
+function getExtension(params) {
+  return params && params.extension || 'br';
+}
+
 function compress(params) {
   params = params || {};
+
+  var extension = getExtension(params);
 
   return through.obj(function(file, enc, cb) {
     if (file.isNull()) {
@@ -15,7 +21,7 @@ function compress(params) {
       return;
     }
 
-    file.path += '.br';
+    file.path += '.' + extension;
 
     if (file.isStream()) {
       file.contents = file.contents.pipe(brotli.compressStream(params));
@@ -36,14 +42,16 @@ function compress(params) {
   });
 }
 
-function decompress() {
+function decompress(params) {
+  var extension = getExtension(params);
+  var reExtension = new RegExp('.' + extension + '$', 'i');
   return through.obj(function(file, enc, cb) {
     if (file.isNull()) {
       cb(null, file);
       return;
     }
 
-    file.path = file.path.replace(/\.br$/i, '');
+    file.path = file.path.replace(reExtension, '');
 
     if (file.isStream()) {
       file.contents = file.contents.pipe(brotli.decompressStream());

--- a/test/test.js
+++ b/test/test.js
@@ -29,6 +29,31 @@ describe('gulp-brotli', function() {
     });
   });
 
+  describe('custom extension', function() {
+    it('should support custom extensions', function(done) {
+      var fakeFile = new File({
+        path: '/test/file',
+        contents: es.readArray(['this', 'is', 'custom', 'brotli'])
+      });
+
+      var compresser = brotli.compress({
+        extension: 'brotli'
+      });
+      compresser.write(fakeFile);
+      assert.equal(fakeFile.path, '/test/file.brotli');
+
+      compresser.pipe(brotli.decompress({ extension: 'brotli' })).once('data', function(file) {
+        assert(file.isStream());
+        assert.equal(file.path, '/test/file');
+
+        file.contents.pipe(es.wait(function(err, data) {
+          assert.equal(data.toString(), 'thisiscustombrotli');
+          done();
+        }));
+      });
+    });
+  });
+
   describe('buffer mode', function() {
     it('should compress and decompress', function(done) {
       var fakeFile = new File({


### PR DESCRIPTION
As discussed [here](https://kevinlocke.name/bits/2016/01/20/serving-pre-compressed-files-with-apache-multiviews/) there is no official extension for brotli files yet. Furthermore files with the `.br` extension introduce issues in Apache since `.br` is the [ISO 639 language code](https://www.loc.gov/standards/iso639-2/php/code_list.php) for Breton. 

Therefore I have added support for custom extensions.

This PR includes:
- Necessary code changes
- A test for the added functionality
- Updated README file

I have used more or less the same approach as the [gulp-gzip](https://github.com/jstuckey/gulp-gzip) plugin.
